### PR TITLE
make the responses of listing alerts apis consistent

### DIFF
--- a/pkg/kapis/alerting/v2alpha1/register.go
+++ b/pkg/kapis/alerting/v2alpha1/register.go
@@ -78,7 +78,7 @@ func AddToContainer(container *restful.Container, informers informers.InformerFa
 	ws.Route(ws.GET("/rules/{rule_name}/alerts").
 		To(handler.handleListCustomRuleAlerts).
 		Doc("list the alerts of the cluster-level custom alerting rule with the specified name").
-		Returns(http.StatusOK, ksapi.StatusOK, []alertingv2alpha1.Alert{}).
+		Returns(http.StatusOK, ksapi.StatusOK, alertingv2alpha1.AlertList{}).
 		Metadata(restfulspec.KeyOpenAPITags, []string{constants.AlertingTag}))
 
 	ws.Route(ws.POST("/rules").
@@ -134,7 +134,7 @@ func AddToContainer(container *restful.Container, informers informers.InformerFa
 	ws.Route(ws.GET("/namespaces/{namespace}/rules/{rule_name}/alerts").
 		To(handler.handleListCustomRuleAlerts).
 		Doc("get the alerts of the custom alerting rule with the specified name in the specified namespace").
-		Returns(http.StatusOK, ksapi.StatusOK, []alertingv2alpha1.Alert{}).
+		Returns(http.StatusOK, ksapi.StatusOK, alertingv2alpha1.AlertList{}).
 		Metadata(restfulspec.KeyOpenAPITags, []string{constants.AlertingTag}))
 
 	ws.Route(ws.POST("/namespaces/{namespace}/rules").
@@ -190,7 +190,7 @@ func AddToContainer(container *restful.Container, informers informers.InformerFa
 	ws.Route(ws.GET("/builtin/rules/{rule_id}/alerts").
 		To(handler.handleListBuiltinRuleAlerts).
 		Doc("list the alerts of the builtin(non-custom) alerting rule with the specified id").
-		Returns(http.StatusOK, ksapi.StatusOK, []alertingv2alpha1.Alert{}).
+		Returns(http.StatusOK, ksapi.StatusOK, alertingv2alpha1.AlertList{}).
 		Metadata(restfulspec.KeyOpenAPITags, []string{constants.AlertingTag}))
 
 	container.Add(ws)

--- a/pkg/models/alerting/alerting.go
+++ b/pkg/models/alerting/alerting.go
@@ -48,7 +48,7 @@ type Operator interface {
 	// GetCustomAlertingRule gets the custom alerting rule with the given name.
 	GetCustomAlertingRule(ctx context.Context, namespace, ruleName string) (*v2alpha1.GettableAlertingRule, error)
 	// ListCustomRuleAlerts lists the alerts of the custom alerting rule with the given name.
-	ListCustomRuleAlerts(ctx context.Context, namespace, ruleName string) ([]*v2alpha1.Alert, error)
+	ListCustomRuleAlerts(ctx context.Context, namespace, ruleName string) (*v2alpha1.AlertList, error)
 	// CreateCustomAlertingRule creates a custom alerting rule.
 	CreateCustomAlertingRule(ctx context.Context, namespace string, rule *v2alpha1.PostableAlertingRule) error
 	// UpdateCustomAlertingRule updates the custom alerting rule with the given name.
@@ -65,7 +65,7 @@ type Operator interface {
 	// GetBuiltinAlertingRule gets the builtin(non-custom) alerting rule with the given id
 	GetBuiltinAlertingRule(ctx context.Context, ruleId string) (*v2alpha1.GettableAlertingRule, error)
 	// ListBuiltinRuleAlerts lists the alerts of the builtin(non-custom) alerting rule with the given id
-	ListBuiltinRuleAlerts(ctx context.Context, ruleId string) ([]*v2alpha1.Alert, error)
+	ListBuiltinRuleAlerts(ctx context.Context, ruleId string) (*v2alpha1.AlertList, error)
 }
 
 func NewOperator(informers informers.InformerFactory,
@@ -184,7 +184,7 @@ func (o *operator) GetCustomAlertingRule(ctx context.Context, namespace, ruleNam
 }
 
 func (o *operator) ListCustomRuleAlerts(ctx context.Context, namespace, ruleName string) (
-	[]*v2alpha1.Alert, error) {
+	*v2alpha1.AlertList, error) {
 
 	rule, err := o.GetCustomAlertingRule(ctx, namespace, ruleName)
 	if err != nil {
@@ -193,7 +193,10 @@ func (o *operator) ListCustomRuleAlerts(ctx context.Context, namespace, ruleName
 	if rule == nil {
 		return nil, v2alpha1.ErrAlertingRuleNotFound
 	}
-	return rule.Alerts, nil
+	return &v2alpha1.AlertList{
+		Total: len(rule.Alerts),
+		Items: rule.Alerts,
+	}, nil
 }
 
 func (o *operator) ListBuiltinAlertingRules(ctx context.Context,
@@ -223,7 +226,7 @@ func (o *operator) GetBuiltinAlertingRule(ctx context.Context, ruleId string) (
 	return o.getBuiltinAlertingRule(ctx, ruleId)
 }
 
-func (o *operator) ListBuiltinRuleAlerts(ctx context.Context, ruleId string) ([]*v2alpha1.Alert, error) {
+func (o *operator) ListBuiltinRuleAlerts(ctx context.Context, ruleId string) (*v2alpha1.AlertList, error) {
 	rule, err := o.getBuiltinAlertingRule(ctx, ruleId)
 	if err != nil {
 		return nil, err
@@ -231,7 +234,10 @@ func (o *operator) ListBuiltinRuleAlerts(ctx context.Context, ruleId string) ([]
 	if rule == nil {
 		return nil, v2alpha1.ErrAlertingRuleNotFound
 	}
-	return rule.Alerts, nil
+	return &v2alpha1.AlertList{
+		Total: len(rule.Alerts),
+		Items: rule.Alerts,
+	}, nil
 }
 
 func (o *operator) ListClusterAlertingRules(ctx context.Context, customFlag string,


### PR DESCRIPTION
**What type of PR is this?**
> Uncomment only one ` /kind <>` line, hit enter to put that in a new line, and remove leading whitespaces from that line:
>
> /kind api-change
> /kind bug
> /kind cleanup
> /kind design
> /kind documentation
> /kind failing-test
> /kind feature
> /kind flake

**What this PR does / why we need it**:

**Which issue(s) this PR fixes**:
<!--
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

**Special notes for reviewers**:
```
```

**Additional documentation, usage docs, etc.**:

<!--
This section can be blank if this pull request does not require a release note.
Please use the following format for linking documentation or pass the
section below:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs

```
